### PR TITLE
Fix pasting seeds with a trailing newline

### DIFF
--- a/src/Utils/setRngState.js
+++ b/src/Utils/setRngState.js
@@ -1,5 +1,5 @@
 export const setRngStateFromClipboard = (event, setState) => {
-  const text = event.clipboardData.getData('Text').split('\n');
+  const text = event.clipboardData.getData('Text').split('\n').filter(line => line.trim());
 
   if (text.length === 4) {
     setState(state => ({


### PR DESCRIPTION
👋 

When I copy the S[0-3] box from Project_Xs on macOS, there are four lines containing a seed, but also a trailing newline at the end. As a result, pasting those lines into Chatot didn't autofill all four seed boxes because Chatot thought I was pasting five lines. (Edit: Specifically, it looks like the newline gets included in the clipboard when I use command-A in the textbox, but not always when I highlight via clicking and dragging.)

This commit makes the pasting logic more lenient by ignoring lines that contain only whitespace.